### PR TITLE
feat(rollbar-browser): add ability to report to browser, or use for custom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 rollbar.sublime-project
 rollbar.sublime-workspace
+/node_modules/
+/.idea

--- a/README.md
+++ b/README.md
@@ -24,16 +24,44 @@ cordova plugin add https://github.com/Resgrid/cordova-plugins-rollbar.git --vari
 ```
 
 ## Usage ##
-After device ready call the following line of code to initialize the Rollbar plugin. Note that the token and environment are pulled form the plugin vairables.
+After device ready call the following line of code to initialize the Rollbar plugin. Note that the token and environment are pulled form the plugin variables.
 
 ```
-cordova.plugins.Rollbar.init();
+cordova.plugins.Rollbar.native.init();
+```
+
+For custom usage of rollbar, do:
+```
+const Rollbar = cordova.plugins.Rollbar.browser.init({
+    accessToken: TOKEN,
+    captureUncaught: true,
+    captureUnhandledRejections: true,
+    payload: {
+        environment: "development"
+    }
+});
+```
+
+And then you can use that `Rollbar` object normally, for example as an Ionic error handler:
+```
+export class MyErrorHandler extends IonicErrorHandler implements ErrorHandler {
+    handleError(error: any): void {
+        if (useRollbar) {
+            console.warn("Reporting to Rollbar");
+            console.error(error);
+            Rollbar.error(error);
+        }
+
+        super.handleError(error);
+    }
+}
 ```
 
 ## Supported Platforms ##
 
 - Android
 - iOS
+- Browser
 
 ## Notes ##
 Currently in development, we welcome PR's and other fixes. Hope to have it production ready soon.

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "bugs": {
     "url": "https://github.com/Resgrid/cordova-plugins-rollbar/issues"
   },
-  "homepage": "https://github.com/Resgrid/cordova-plugins-rollbar"
+  "homepage": "https://github.com/Resgrid/cordova-plugins-rollbar",
+  "dependencies": {
+    "rollbar-browser": "^1.9.4"
+  }
 }

--- a/www/rollbar.js
+++ b/www/rollbar.js
@@ -7,11 +7,19 @@
  */
 
 var exec = require('cordova/exec');
+var RollbarSetup = require('rollbar-browser/dist/rollbar.umd.nojson.js');
 
-var Rollbar = {};
-
-Rollbar.init = function(successCallback, errorCallback){
-  return exec(successCallback, errorCallback, "CDVRollbar", "init", []);
+var Rollbar = {
+  native: {
+    init: function(successCallback, errorCallback){
+      return exec(successCallback, errorCallback, "CDVRollbar", "init", []);
+    }
+  },
+  browser: {
+    init: function(config) {
+      return RollbarSetup.init(config);
+    }
+  }
 };
 
 module.exports = Rollbar;


### PR DESCRIPTION
Breaking change: `Rollbar.init()` is now `Rollbar.native.init()`
Added the ability to use rollbar browser in the same import, in `Rollbar.browser.init(config)`

This was not tested, but this is the exact logic that exists in my code right now.
I did not use a minified file in the `require`, as there are no minified files in `rollbar-browser` dist on npm.

Solves: https://github.com/Resgrid/cordova-plugins-rollbar/issues/7
Makes unneeded: https://github.com/Resgrid/cordova-plugins-rollbar/issues/3